### PR TITLE
initial db schema for matchmaking flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# tugma.dev
+# varo.dev
 
 TODO readme

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,7 +4,7 @@ const { user, clear } = useUserSession();
 </script>
 <template>
     <div class="flex flex-col gap-4 p-6">
-        <h1 class="text-4xl font-bold">Tugma.dev</h1>
+        <h1 class="text-4xl font-bold">varo.dev</h1>
         <div class="flex items-center gap-2">
             This is an unprotected page:
             <pre class="rounded-md border bg-slate-50 p-1">routes/index.tsx</pre>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -24,13 +24,13 @@ export default defineNuxtConfig({
     databaseUrl: process.env.NUXT_DATABASE_URL,
 
     sessionPassword: process.env.NUXT_SESSION_PASSWORD,
-    baseUrl: process.env.NUXT_BASE_URL, // The URL of your deployed app (used for origin Check in production)
+    baseUrl: process.env.NUXT_BASE_URL,
 
     oauth: {
       github: {
         clientId: process.env.NUXT_GITHUB_CLIENT_ID,
         clientSecret: process.env.NUXT_GITHUB_CLIENT_SECRET,
-        redirectURL: process.env.NUXT_GITHUB_REDIRECT_URL,
+        redirectURL: process.env.NUXT_BASE_URL! + process.env.NUXT_GITHUB_REDIRECT_PATH,
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: "2024-10-07",
-  // devtools: { enabled: true },
+  devtools: { enabled: true },
 
   future: {
     compatibilityVersion: 4,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "hasInstallScript": true,
       "dependencies": {
         "@nuxt/eslint": "^0.5.7",
-        "@nuxt/fonts": "^0.9.2",
-        "@nuxthub/core": "^0.7.24",
+        "@nuxt/fonts": "^0.10.0",
+        "@nuxthub/core": "^0.7.26",
         "@vant/nuxt": "^1.0.6",
         "@vueuse/core": "^11.1.0",
-        "drizzle-orm": "^0.33.0",
+        "drizzle-orm": "^0.34.1",
         "nuxt": "^3.13.2",
-        "nuxt-auth-utils": "^0.4.2",
+        "nuxt-auth-utils": "^0.4.4",
         "nuxt-build-cache": "^0.1.1",
         "nuxt-typed-router": "^3.7.0",
         "pinia": "^2.2.4",
@@ -25,11 +25,11 @@
         "@nuxtjs/tailwindcss": "^6.12.1",
         "@pinia/nuxt": "^0.5.5",
         "@vueuse/nuxt": "^11.1.0",
-        "drizzle-kit": "^0.24.2",
+        "drizzle-kit": "^0.25.0",
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.8",
         "sass": "^1.79.4",
-        "wrangler": "^3.80.0"
+        "wrangler": "^3.80.1"
       }
     },
     "node_modules/@adonisjs/hash": {
@@ -2522,28 +2522,29 @@
       }
     },
     "node_modules/@nuxt/fonts": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/fonts/-/fonts-0.9.2.tgz",
-      "integrity": "sha512-RMekoJh5AIaKG3tu0YaCdru3eTqNdXn6v7ggh5cdG4rWugr59HzihZ6n4C2Pkkv6nxOP4DOhxxdOwcZwXZM5vQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/fonts/-/fonts-0.10.0.tgz",
+      "integrity": "sha512-VoK/rssN1PzMeQOplap8UYnbKtI6IDaI+sj5BmbCCpXRYY84gH8m+zePGRo88Mi9ujRhd1HUOXfsCvHN88iGmQ==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/devtools-kit": "^1.5.1",
+        "@nuxt/devtools-kit": "^1.5.2",
         "@nuxt/kit": "^3.13.2",
         "chalk": "^5.3.0",
         "css-tree": "^3.0.0",
         "defu": "^6.1.4",
         "esbuild": "^0.24.0",
         "fontaine": "^0.5.0",
-        "h3": "^1.12.0",
-        "jiti": "^1.21.6",
+        "h3": "^1.13.0",
+        "jiti": "^2.3.3",
         "magic-regexp": "^0.8.0",
         "magic-string": "^0.30.11",
         "node-fetch-native": "^1.6.4",
         "ohash": "^1.1.4",
         "pathe": "^1.1.2",
         "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
+        "tinyglobby": "^0.2.9",
         "ufo": "^1.5.4",
+        "unifont": "^0.1.0",
         "unplugin": "^1.14.1",
         "unstorage": "^1.12.0"
       }
@@ -2986,6 +2987,15 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/@nuxt/kit/node_modules/jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/@nuxt/schema": {
       "version": "3.13.2",
       "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.13.2.tgz",
@@ -3036,6 +3046,15 @@
       },
       "bin": {
         "nuxt-telemetry": "bin/nuxt-telemetry.mjs"
+      }
+    },
+    "node_modules/@nuxt/telemetry/node_modules/jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/@nuxt/vite-builder": {
@@ -3521,9 +3540,9 @@
       }
     },
     "node_modules/@nuxthub/core": {
-      "version": "0.7.24",
-      "resolved": "https://registry.npmjs.org/@nuxthub/core/-/core-0.7.24.tgz",
-      "integrity": "sha512-ChDevUWPhhjiyf4WbZI/ynDLJZT9yyWOcXHEQa8IcOmBk6F81D10QQUrR7HFtP+WhEgZyo1EulhVs6bnL5uYQg==",
+      "version": "0.7.26",
+      "resolved": "https://registry.npmjs.org/@nuxthub/core/-/core-0.7.26.tgz",
+      "integrity": "sha512-xOfI+txczteKk66cxf9Rb5AL/PttcS47FCotzXVCZflS4xgnJfZb42FurKYagozpu1MbM6V95nXhO/esg3xUbA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudflare/workers-types": "^4.20241004.0",
@@ -3531,7 +3550,7 @@
         "@nuxt/kit": "^3.13.2",
         "@uploadthing/mime-types": "^0.3.0",
         "citty": "^0.1.6",
-        "confbox": "^0.1.7",
+        "confbox": "^0.1.8",
         "defu": "^6.1.4",
         "destr": "^2.0.3",
         "h3": "^1.13.0",
@@ -4440,9 +4459,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
-      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -4483,16 +4502,16 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.8.0.tgz",
-      "integrity": "sha512-wORFWjU30B2WJ/aXBfOm1LX9v9nyt9D3jsSOxC3cCaTQGCW5k4jNpmjFv3U7p/7s4yvdjHzwtv2Sd2dOyhjS0A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.8.1.tgz",
+      "integrity": "sha512-xfvdgA8AP/vxHgtgU310+WBnLB4uJQ9XdyP17RebG26rLtDrQJV3ZYrcopX91GrHmMoH8bdSwMRh2a//TiJ1jQ==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/type-utils": "8.8.0",
-        "@typescript-eslint/utils": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/scope-manager": "8.8.1",
+        "@typescript-eslint/type-utils": "8.8.1",
+        "@typescript-eslint/utils": "8.8.1",
+        "@typescript-eslint/visitor-keys": "8.8.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -4516,15 +4535,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.8.0.tgz",
-      "integrity": "sha512-uEFUsgR+tl8GmzmLjRqz+VrDv4eoaMqMXW7ruXfgThaAShO9JTciKpEsB+TvnfFfbg5IpujgMXVV36gOJRLtZg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.8.1.tgz",
+      "integrity": "sha512-hQUVn2Lij2NAxVFEdvIGxT9gP1tq2yM83m+by3whWFsWC+1y8pxxxHUFE1UqDu2VsGi2i6RLcv4QvouM84U+ow==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/typescript-estree": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/scope-manager": "8.8.1",
+        "@typescript-eslint/types": "8.8.1",
+        "@typescript-eslint/typescript-estree": "8.8.1",
+        "@typescript-eslint/visitor-keys": "8.8.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4544,13 +4563,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.8.0.tgz",
-      "integrity": "sha512-EL8eaGC6gx3jDd8GwEFEV091210U97J0jeEHrAYvIYosmEGet4wJ+g0SYmLu+oRiAwbSA5AVrt6DxLHfdd+bUg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.8.1.tgz",
+      "integrity": "sha512-X4JdU+66Mazev/J0gfXlcC/dV6JI37h+93W9BRYXrSn0hrE64IoWgVkO9MSJgEzoWkxONgaQpICWg8vAN74wlA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0"
+        "@typescript-eslint/types": "8.8.1",
+        "@typescript-eslint/visitor-keys": "8.8.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4561,13 +4580,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.8.0.tgz",
-      "integrity": "sha512-IKwJSS7bCqyCeG4NVGxnOP6lLT9Okc3Zj8hLO96bpMkJab+10HIfJbMouLrlpyOr3yrQ1cA413YPFiGd1mW9/Q==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.8.1.tgz",
+      "integrity": "sha512-qSVnpcbLP8CALORf0za+vjLYj1Wp8HSoiI8zYU5tHxRVj30702Z1Yw4cLwfNKhTPWp5+P+k1pjmD5Zd1nhxiZA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.8.0",
-        "@typescript-eslint/utils": "8.8.0",
+        "@typescript-eslint/typescript-estree": "8.8.1",
+        "@typescript-eslint/utils": "8.8.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -4585,9 +4604,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.8.0.tgz",
-      "integrity": "sha512-QJwc50hRCgBd/k12sTykOJbESe1RrzmX6COk8Y525C9l7oweZ+1lw9JiU56im7Amm8swlz00DRIlxMYLizr2Vw==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.8.1.tgz",
+      "integrity": "sha512-WCcTP4SDXzMd23N27u66zTKMuEevH4uzU8C9jf0RO4E04yVHgQgW+r+TeVTNnO1KIfrL8ebgVVYYMMO3+jC55Q==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4598,13 +4617,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.8.0.tgz",
-      "integrity": "sha512-ZaMJwc/0ckLz5DaAZ+pNLmHv8AMVGtfWxZe/x2JVEkD5LnmhWiQMMcYT7IY7gkdJuzJ9P14fRy28lUrlDSWYdw==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.8.1.tgz",
+      "integrity": "sha512-A5d1R9p+X+1js4JogdNilDuuq+EHZdsH9MjTVxXOdVFfTJXunKJR/v+fNNyO4TnoOn5HqobzfRlc70NC6HTcdg==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/types": "8.8.1",
+        "@typescript-eslint/visitor-keys": "8.8.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -4626,15 +4645,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.8.0.tgz",
-      "integrity": "sha512-QE2MgfOTem00qrlPgyByaCHay9yb1+9BjnMFnSFkUKQfu7adBXDTnCAivURnuPPAG/qiB+kzKkZKmKfaMT0zVg==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.8.1.tgz",
+      "integrity": "sha512-/QkNJDbV0bdL7H7d0/y0qBbV2HTtf0TIyjSDTvvmQEzeVx8jEImEbLuOA4EsvE8gIgqMitns0ifb5uQhMj8d9w==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/typescript-estree": "8.8.0"
+        "@typescript-eslint/scope-manager": "8.8.1",
+        "@typescript-eslint/types": "8.8.1",
+        "@typescript-eslint/typescript-estree": "8.8.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4648,12 +4667,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.8.0.tgz",
-      "integrity": "sha512-8mq51Lx6Hpmd7HnA2fcHQo3YgfX1qbccxQOgZcb4tvasu//zXRaA1j5ZRFeCw/VRAdFi4mRM9DnZw0Nu0Q2d1g==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.8.1.tgz",
+      "integrity": "sha512-0/TdC3aeRAsW7MDvYRwEc1Uwm0TIBfzjPFgg60UU2Haj5qsCs9cc3zNgY71edqE3LbWfF/WoZQd3lJoDXFQpag==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
+        "@typescript-eslint/types": "8.8.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -5962,6 +5981,15 @@
         }
       }
     },
+    "node_modules/c12/node_modules/jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -7018,9 +7046,9 @@
       }
     },
     "node_modules/drizzle-kit": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.24.2.tgz",
-      "integrity": "sha512-nXOaTSFiuIaTMhS8WJC2d4EBeIcN9OSt2A2cyFbQYBAZbi7lRsVGJNqDpEwPqYfJz38yxbY/UtbvBBahBfnExQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.25.0.tgz",
+      "integrity": "sha512-Rcf0nYCAKizwjWQCY+d3zytyuTbDb81NcaPor+8NebESlUz1+9W3uGl0+r9FhU4Qal5Zv9j/7neXCSCe7DHzjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7464,15 +7492,15 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.33.0.tgz",
-      "integrity": "sha512-SHy72R2Rdkz0LEq0PSG/IdvnT3nGiWuRk+2tXZQ90GVq/XQhpCzu/EFT3V2rox+w8MlkBQxifF8pCStNYnERfA==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.34.1.tgz",
+      "integrity": "sha512-t+zCwyWWt8xTqtYV4doE/xYmT7hpv1L8pQ66zddEz+3VWyedBBtctjMAp22mAJPfyWurRQXUJ1nrTtqLq+DqNA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=3",
         "@electric-sql/pglite": ">=0.1.1",
-        "@libsql/client": "*",
+        "@libsql/client": ">=0.10.0",
         "@neondatabase/serverless": ">=0.1",
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
@@ -7603,9 +7631,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.32",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.32.tgz",
-      "integrity": "sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==",
+      "version": "1.5.33",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.33.tgz",
+      "integrity": "sha512-+cYTcFB1QqD4j4LegwLfpCNxifb6dDFUAwk6RsLusCwIaZI6or2f+q8rs5tTB2YC53HhOlIbEaqHMAAC8IOIwA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -9641,12 +9669,12 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.6",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
-      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.3.3.tgz",
+      "integrity": "sha512-EX4oNDwcXSivPrw2qKH2LB5PoFxEvgtv2JgwW0bU858HoLQ+kutSvjLMUqBd0PeJYEinLWhoI9Ol0eYMqj/wNQ==",
       "license": "MIT",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {
@@ -10095,15 +10123,6 @@
         "listhen": "bin/listhen.mjs"
       }
     },
-    "node_modules/listhen/node_modules/jiti": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.3.1.tgz",
-      "integrity": "sha512-xPZ6pPzUifI8XDBBxIL4OB1w1ZKmBpmNEeKwNt2d0Spn8XisAIZhWrlOHq5seBrFGTxVx9PbrWvEMyrk4IO5bA==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -10409,9 +10428,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20240925.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240925.0.tgz",
-      "integrity": "sha512-2LmQbKHf0n6ertUKhT+Iltixi53giqDH7P71+wCir3OnGyXIODqYwOECx1mSDNhYThpxM2dav8UdPn6SQiMoXw==",
+      "version": "3.20240925.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240925.1.tgz",
+      "integrity": "sha512-odavnAwWLevMWOi/efIdAI9AVlg8C8NfXe2YLoAeG+Fj5BDHPDxCoY7AjZvBj3CJ7bszkoYyhoPEH60X+Vk+7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11273,6 +11292,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nitropack/node_modules/jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -11544,9 +11572,9 @@
       }
     },
     "node_modules/nuxt-auth-utils": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/nuxt-auth-utils/-/nuxt-auth-utils-0.4.2.tgz",
-      "integrity": "sha512-qDzSye1EovzlFkfnNOZyYdg9YXIlm75MqawsMdhDpH1n9bVZ2ydNyfHEZbpc1NWs5YfX3TyeJFpuvaXb4O/6yA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/nuxt-auth-utils/-/nuxt-auth-utils-0.4.4.tgz",
+      "integrity": "sha512-yAtxI4rSyQXcdBy5hQO1foLxigdsRSWdkrzcGSWEtg/+gafsqDikYMARPGWkdXshyu17wH60d+TjspqAnfsvIw==",
       "license": "MIT",
       "dependencies": {
         "@adonisjs/hash": "^9.0.5",
@@ -12041,6 +12069,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nuxt/node_modules/jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/nuxt/node_modules/tinyglobby": {
@@ -12561,13 +12598,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.0.tgz",
-      "integrity": "sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
+      "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.1.7",
-        "mlly": "^1.7.1",
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.2",
         "pathe": "^1.1.2"
       }
     },
@@ -15032,9 +15069,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/synckit": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
-      "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
       "license": "MIT",
       "dependencies": {
         "@pkgr/core": "^0.1.0",
@@ -15207,6 +15244,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/tailwindcss/node_modules/lilconfig": {
@@ -15627,6 +15674,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unifont": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.1.0.tgz",
+      "integrity": "sha512-A9fX7w4mFhKBiP1ecDTN43QssU4vd8IQuoaxzz6PXu6bvNDJC4pV+FNWrJm/P0n8lk/3oXQBJxHs5GHVCBPBpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.4",
+        "ohash": "^1.1.4",
+        "ufo": "^1.5.4"
+      }
+    },
     "node_modules/unimport": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/unimport/-/unimport-3.13.1.tgz",
@@ -15830,15 +15890,6 @@
       },
       "bin": {
         "untyped": "dist/cli.mjs"
-      }
-    },
-    "node_modules/untyped/node_modules/jiti": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.3.1.tgz",
-      "integrity": "sha512-xPZ6pPzUifI8XDBBxIL4OB1w1ZKmBpmNEeKwNt2d0Spn8XisAIZhWrlOHq5seBrFGTxVx9PbrWvEMyrk4IO5bA==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/unwasm": {
@@ -16534,9 +16585,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.80.0.tgz",
-      "integrity": "sha512-c9aN7Buf7XgTPpQkw1d0VjNRI4qg3m35PTg70Tg4mOeHwHGjsd74PAsP1G8BjpdqDjfWtsua7tj1g4M3/5dYNQ==",
+      "version": "3.80.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.80.1.tgz",
+      "integrity": "sha512-5pBZpzrGpfAtIzF3iBXfZZ9DoP8OjwfIUYjYmddfkmoe6fSyY5r/+IFP56fb/biK5q6FV5HxUnonDiuNyJKnug==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -16547,7 +16598,7 @@
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
         "esbuild": "0.17.19",
-        "miniflare": "3.20240925.0",
+        "miniflare": "3.20240925.1",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.3.0",
         "resolve": "^1.22.8",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
   },
   "dependencies": {
     "@nuxt/eslint": "^0.5.7",
-    "@nuxt/fonts": "^0.9.2",
-    "@nuxthub/core": "^0.7.24",
+    "@nuxt/fonts": "^0.10.0",
+    "@nuxthub/core": "^0.7.26",
     "@vant/nuxt": "^1.0.6",
     "@vueuse/core": "^11.1.0",
-    "drizzle-orm": "^0.33.0",
+    "drizzle-orm": "^0.34.1",
     "nuxt": "^3.13.2",
-    "nuxt-auth-utils": "^0.4.2",
+    "nuxt-auth-utils": "^0.4.4",
     "nuxt-build-cache": "^0.1.1",
     "nuxt-typed-router": "^3.7.0",
     "pinia": "^2.2.4",
@@ -31,11 +31,11 @@
     "@nuxtjs/tailwindcss": "^6.12.1",
     "@pinia/nuxt": "^0.5.5",
     "@vueuse/nuxt": "^11.1.0",
-    "drizzle-kit": "^0.24.2",
+    "drizzle-kit": "^0.25.0",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.8",
     "sass": "^1.79.4",
-    "wrangler": "^3.80.0"
+    "wrangler": "^3.80.1"
   },
   "overrides": {
     "vue": "latest"

--- a/server/api/auth/github.get.ts
+++ b/server/api/auth/github.get.ts
@@ -2,9 +2,16 @@ export default defineOAuthGitHubEventHandler({
   config: {
     emailRequired: true,
   },
-  async onSuccess(event, { user, tokens }) {
-    console.log(user); // TODO: restructure
-    await setUserSession(event, { user });
+  async onSuccess(event, { user }) {
+    await setUserSession(event, {
+      user: {
+        id: user.id,
+        username: user.login,
+        name: user.name,
+        email: user.email,
+        avatar_url: user.avatar_url,
+      },
+    });
     return sendRedirect(event, "/");
   },
   // Optional, will return a json error and 401 status code by default

--- a/server/schemas/index.ts
+++ b/server/schemas/index.ts
@@ -20,6 +20,7 @@ export const match_status_enum = pgEnum("match_status_enum", [
 
 export const users = pgTable("users", {
   id: text().primaryKey(),
+  username: text().unique(),
   name: text(),
   first_name: text(),
   last_name: text(),

--- a/server/schemas/index.ts
+++ b/server/schemas/index.ts
@@ -12,129 +12,131 @@ import {
 
 // maybe convert to barrel file if we're using Nuxt Layers?
 
-export const matchStatusEnum = pgEnum("match_status_enum", [
+export const match_status_enum = pgEnum("match_status_enum", [
   "pending",
   "accepted",
   "rejected",
 ]);
 
-export const user = pgTable("user", {
-  id: text("id").primaryKey(),
-  name: text("name"),
-  firstName: text("first_name"),
-  lastName: text("last_name"),
-  avatarUrl: text("avatar_url"),
-  email: text("email").unique().notNull(),
+export const users = pgTable("users", {
+  id: text().primaryKey(),
+  name: text(),
+  first_name: text(),
+  last_name: text(),
+  avatar_url: text(),
+  email: text().unique().notNull(),
 
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  created_at: timestamp().defaultNow().notNull(),
+  updated_at: timestamp()
     .defaultNow()
     .notNull()
     .$onUpdate(() => new Date()),
-  setupAt: timestamp("setup_at"),
-  termsAcceptedAt: timestamp("terms_accepted_at"),
+  setup_at: timestamp(),
+  terms_accepted_at: timestamp(),
 
-  bio: text("bio"),
-  location: text("location"),
-  experienceLevel: integer("experience_level"),
-  availability: text("availability"),
+  bio: text(),
+  location: text(),
+  experience_level: integer(),
+  availability: text(),
 
   // TODO: should we use separate tables for these? (also for project table)
-  skills: text("skills")
+  skills: text()
     .array()
     .notNull()
     .default(sql`ARRAY[]::text[]`),
-  techStack: text("tech_stack")
+  tech_stack: text()
     .array()
     .notNull()
     .default(sql`ARRAY[]::text[]`),
-  interests: text("interests")
+  interests: text()
     .array()
     .notNull()
     .default(sql`ARRAY[]::text[]`),
 
-  embedding: vector("embedding", { dimensions: 1536 }),
+  embedding: vector({ dimensions: 1536 }),
 });
 
-export const oauthAccount = pgTable(
-  "oauth_account",
+export const oauthAccounts = pgTable(
+  "oauth_accounts",
   {
-    providerId: text("provider_id"),
-    providerUserId: text("provider_user_id"),
-    userId: text("user_id")
+    provider_id: text(),
+    provider_user_id: text(),
+    user_id: text()
       .notNull()
-      .references(() => user.id),
+      .references(() => users.id),
   },
-  (table) => ({ pk: primaryKey({ columns: [table.providerId, table.providerUserId] }) }),
+  (table) => ({
+    pk: primaryKey({ columns: [table.provider_id, table.provider_user_id] }),
+  }),
 );
 
-export const project = pgTable("project", {
-  id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-  name: text("name"),
-  description: text("description"),
-  repoUrl: text("repo_url"),
-  websiteUrl: text("website_url"),
-  ownerId: text("owner_id").references(() => user.id),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+export const projects = pgTable("projects", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  name: text(),
+  description: text(),
+  repo_url: text(),
+  website_url: text(),
+  owner_id: text().references(() => users.id),
+  created_at: timestamp().defaultNow().notNull(),
+  updated_at: timestamp()
     .defaultNow()
     .notNull()
     .$onUpdate(() => new Date()),
 
-  matchEnabled: boolean("match_enabled").default(false), // or helpWanted?
-  skills: text("skills")
+  match_enabled: boolean().default(false), // or help_wanted?
+  skills: text()
     .array()
     .notNull()
     .default(sql`ARRAY[]::text[]`),
-  techStack: text("tech_stack")
+  tech_stack: text()
     .array()
     .notNull()
     .default(sql`ARRAY[]::text[]`),
-  categories: text("categories")
+  categories: text()
     .array()
     .notNull()
     .default(sql`ARRAY[]::text[]`),
-  helpDescription: text("help_description"),
+  help_description: text(),
 
-  embedding: vector("embedding", { dimensions: 1536 }),
+  embedding: vector({ dimensions: 1536 }),
 });
 
-export const userMatch = pgTable(
-  "user_match",
+export const userMatches = pgTable(
+  "user_matches",
   {
-    user1Id: text("user1_id").references(() => user.id),
-    user2Id: text("user2_id").references(() => user.id),
+    user1_id: text().references(() => users.id),
+    user2_id: text().references(() => users.id),
 
-    user1Status: matchStatusEnum("user_1_status").default("pending"),
-    user2Status: matchStatusEnum("user_2_status").default("pending"),
+    user1_status: match_status_enum().default("pending"),
+    user2_status: match_status_enum().default("pending"),
 
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    created_at: timestamp().defaultNow().notNull(),
+    updated_at: timestamp()
       .defaultNow()
       .notNull()
       .$onUpdate(() => new Date()),
   },
-  (table) => ({ pk: primaryKey({ columns: [table.user1Id, table.user2Id] }) }),
+  (table) => ({ pk: primaryKey({ columns: [table.user1_id, table.user2_id] }) }),
 );
 
-export const projectMatch = pgTable(
-  "project_match",
+export const projectMatches = pgTable(
+  "project_matches",
   {
-    userId: text("user_id").references(() => user.id),
-    projectId: integer("project_id").references(() => project.id),
+    user_id: text().references(() => users.id),
+    project_id: integer().references(() => projects.id),
 
-    userStatus: matchStatusEnum("user_status").default("pending"),
-    projectStatus: matchStatusEnum("project_status").default("pending"),
+    user_status: match_status_enum().default("pending"),
+    project_status: match_status_enum().default("pending"),
 
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    created_at: timestamp().defaultNow().notNull(),
+    updated_at: timestamp()
       .defaultNow()
       .notNull()
       .$onUpdate(() => new Date()),
   },
-  (table) => ({ pk: primaryKey({ columns: [table.userId, table.projectId] }) }),
+  (table) => ({ pk: primaryKey({ columns: [table.user_id, table.project_id] }) }),
 );
 
 // TODO: add indexes for faster lookups
 
-export type User = typeof user.$inferSelect;
+export type User = typeof users.$inferSelect;

--- a/types/auth.d.ts
+++ b/types/auth.d.ts
@@ -1,0 +1,10 @@
+declare module "#auth-utils" {
+  interface User {
+    id: number;
+    username: string;
+    name: string;
+    email: string;
+    avatar_url: string;
+  }
+}
+export {};


### PR DESCRIPTION
## Proposed matchmaking flow

### For user--user:

1. User 1 is shown match suggestions with other users.
   - `user_match` rows are created with pending statuses
   - These match suggestions can also show for user 2
2. User 1 (or can be 2) accepts suggestion for a user.
3. The other user will see this suggestion (more aggressive if it was already shown previously).
   - If 1 user rejects, flow is cancelled and we can maybe delete this row after some time.
4. If both users accept, the match is successful and they can now message each other or see more details.

### For user--project:

1. User is shown project match suggestions.
2. User expresses interest in a project (user_status to accepted).
3. Project owner/maintainer reviews interested users.
4. Project owner accepts or declines the user.
5. If accepted, match successful.

Or should we add a 3rd confirmation step for user--project matchmaking after project owner accepts? (probably not necessary)

These flows can be initiated when a user registers or updates their profile, or when a new project gets added.

Also review:

- [ ] capitalization for drizzle table fields
- [ ] table naming
- [ ] put skills/techstack/interests/categories in separate table?